### PR TITLE
Add tests for import installments and notifications

### DIFF
--- a/test/components/budget-form.test.tsx
+++ b/test/components/budget-form.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/test/components/dashboard.test.tsx
+++ b/test/components/dashboard.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import { BalanceSummary } from '@/components/balance-summary';

--- a/test/components/event-detail-sheet.test.tsx
+++ b/test/components/event-detail-sheet.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { EventDetailSheet } from '@/components/calendar/event-detail-sheet';

--- a/test/components/field.test.tsx
+++ b/test/components/field.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import {

--- a/test/components/month-agenda-event-item.test.tsx
+++ b/test/components/month-agenda-event-item.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/test/components/transaction-form.test.tsx
+++ b/test/components/transaction-form.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { Account, Category, Transaction, Entry, Income } from '@/lib/schema';

--- a/test/components/transfer-form.test.tsx
+++ b/test/components/transfer-form.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';

--- a/test/lib/actions/import.test.ts
+++ b/test/lib/actions/import.test.ts
@@ -255,5 +255,230 @@ describe('Import Actions', () => {
         expect(result.skippedDuplicates).toBe(0);
       }
     });
+
+    it('skips income with externalId already in income table', async () => {
+      const checking = await seedAccount(testAccounts.checking);
+      await seedCategory('expense');
+      const incomeCategory = await seedCategory('income');
+      const externalId = 'existing-income-uuid';
+
+      await db.insert(schema.income).values({
+        userId: TEST_USER_ID,
+        description: 'Existing Income',
+        amount: 25000,
+        categoryId: incomeCategory.id,
+        accountId: checking.id,
+        receivedDate: '2025-01-15',
+        receivedAt: new Date('2025-01-15T00:00:00Z'),
+        externalId,
+      });
+
+      const result = await importMixed({
+        accountId: checking.id,
+        rows: [
+          {
+            date: '2025-01-15',
+            description: 'Duplicate Income',
+            amountCents: 25000,
+            rowIndex: 0,
+            type: 'income',
+            externalId,
+          },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.importedIncome).toBe(0);
+        expect(result.skippedDuplicates).toBe(1);
+      }
+    });
+  });
+
+  describe('importMixed installment handling', () => {
+    it('imports partial installments when only parcela 2/3 is provided', async () => {
+      const creditCard = await seedAccount(testAccounts.creditCardWithBilling);
+      await seedCategory('expense');
+      await seedCategory('income');
+
+      const result = await importMixed({
+        accountId: creditCard.id,
+        rows: [
+          {
+            date: '2025-01-20',
+            description: 'Notebook - Parcela 2/3',
+            amountCents: 120000,
+            rowIndex: 0,
+            type: 'expense',
+            installmentInfo: {
+              current: 2,
+              total: 3,
+              baseDescription: 'Notebook',
+            },
+          },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.importedExpenses).toBe(1);
+      }
+
+      const [transaction] = await db.select().from(schema.transactions);
+      expect(transaction.totalInstallments).toBe(3);
+      expect(transaction.totalAmount).toBe(360000);
+
+      const entries = await db
+        .select()
+        .from(schema.entries)
+        .where(eq(schema.entries.transactionId, transaction.id));
+      expect(entries).toHaveLength(2);
+
+      const entry2 = entries.find((entry) => entry.installmentNumber === 2);
+      const entry3 = entries.find((entry) => entry.installmentNumber === 3);
+
+      expect(entry2?.purchaseDate).toBe('2025-01-20');
+      expect(entry2?.faturaMonth).toBe('2025-02');
+      expect(entry2?.dueDate).toBe('2025-03-05');
+
+      expect(entry3?.purchaseDate).toBe('2025-02-20');
+      expect(entry3?.faturaMonth).toBe('2025-03');
+      expect(entry3?.dueDate).toBe('2025-04-05');
+      expect(entry3?.amount).toBe(120000);
+    });
+
+    it('adds missing installments to an existing transaction and updates totals', async () => {
+      const checking = await seedAccount(testAccounts.checking);
+      const expenseCategory = await seedCategory('expense');
+      await seedCategory('income');
+
+      const [transaction] = await db
+        .insert(schema.transactions)
+        .values({
+          userId: TEST_USER_ID,
+          description: 'Laptop - Parcela 1/3',
+          totalAmount: 300000,
+          totalInstallments: 3,
+          categoryId: expenseCategory.id,
+        })
+        .returning();
+
+      await db.insert(schema.entries).values([
+        {
+          userId: TEST_USER_ID,
+          transactionId: transaction.id,
+          accountId: checking.id,
+          amount: 100000,
+          purchaseDate: '2025-01-10',
+          faturaMonth: '2025-01',
+          dueDate: '2025-01-10',
+          installmentNumber: 1,
+          paidAt: null,
+        },
+        {
+          userId: TEST_USER_ID,
+          transactionId: transaction.id,
+          accountId: checking.id,
+          amount: 100000,
+          purchaseDate: '2025-02-10',
+          faturaMonth: '2025-02',
+          dueDate: '2025-02-10',
+          installmentNumber: 2,
+          paidAt: null,
+        },
+      ]);
+
+      const result = await importMixed({
+        accountId: checking.id,
+        rows: [
+          {
+            date: '2025-02-10',
+            description: 'Laptop - Parcela 2/3',
+            amountCents: 120000,
+            rowIndex: 0,
+            type: 'expense',
+            installmentInfo: {
+              current: 2,
+              total: 3,
+              baseDescription: 'Laptop',
+            },
+          },
+          {
+            date: '2025-03-10',
+            description: 'Laptop - Parcela 3/3',
+            amountCents: 130000,
+            rowIndex: 1,
+            type: 'expense',
+            installmentInfo: {
+              current: 3,
+              total: 3,
+              baseDescription: 'Laptop',
+            },
+          },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+
+      const entries = await db
+        .select()
+        .from(schema.entries)
+        .where(eq(schema.entries.transactionId, transaction.id));
+      expect(entries).toHaveLength(3);
+
+      const updatedEntry2 = entries.find((entry) => entry.installmentNumber === 2);
+      const entry3 = entries.find((entry) => entry.installmentNumber === 3);
+      expect(updatedEntry2?.amount).toBe(120000);
+      expect(entry3?.amount).toBe(130000);
+      expect(entry3?.purchaseDate).toBe('2025-03-10');
+
+      const [updatedTransaction] = await db
+        .select()
+        .from(schema.transactions)
+        .where(eq(schema.transactions.id, transaction.id));
+      expect(updatedTransaction.totalAmount).toBe(350000);
+    });
+  });
+
+  describe('importMixed mixed expense and income', () => {
+    it('imports expenses and income in a single batch', async () => {
+      const checking = await seedAccount(testAccounts.checking);
+      await seedCategory('expense');
+      await seedCategory('income');
+
+      const result = await importMixed({
+        accountId: checking.id,
+        rows: [
+          {
+            date: '2025-01-05',
+            description: 'Coffee',
+            amountCents: 1500,
+            rowIndex: 0,
+            type: 'expense',
+          },
+          {
+            date: '2025-01-06',
+            description: 'Salary',
+            amountCents: 250000,
+            rowIndex: 1,
+            type: 'income',
+          },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.importedExpenses).toBe(1);
+        expect(result.importedIncome).toBe(1);
+      }
+
+      const transactions = await db.select().from(schema.transactions);
+      const entries = await db.select().from(schema.entries);
+      const incomeRows = await db.select().from(schema.income);
+
+      expect(transactions).toHaveLength(1);
+      expect(entries).toHaveLength(1);
+      expect(incomeRows).toHaveLength(1);
+    });
   });
 });

--- a/test/lib/actions/notifications-scheduling.test.ts
+++ b/test/lib/actions/notifications-scheduling.test.ts
@@ -180,9 +180,10 @@ describe('Notification Scheduling', () => {
 
   it('creates notification jobs for events and ignores disabled configs', async () => {
     const startAt = new Date('2026-05-10T14:00:00Z');
+    const endAt = new Date('2026-05-10T15:00:00Z');
     const [event] = await db
       .insert(schema.events)
-      .values(createTestEvent({ title: 'Event With Notifications', startAt }))
+      .values(createTestEvent({ title: 'Event With Notifications', startAt, endAt }))
       .returning();
 
     await db.insert(schema.notifications).values([
@@ -216,9 +217,10 @@ describe('Notification Scheduling', () => {
 
   it('skips scheduling when the parent item is not owned', async () => {
     const startAt = new Date('2026-06-01T09:00:00Z');
+    const endAt = new Date('2026-06-01T10:00:00Z');
     const [event] = await db
       .insert(schema.events)
-      .values(createTestEvent({ userId: OTHER_USER_ID, startAt }))
+      .values(createTestEvent({ userId: OTHER_USER_ID, startAt, endAt }))
       .returning();
 
     await db.insert(schema.notifications).values({

--- a/test/lib/actions/notifications-scheduling.test.ts
+++ b/test/lib/actions/notifications-scheduling.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import { setupTestDb, teardownTestDb, clearAllTables, getTestDb } from '@/test/db-utils';
 import * as schema from '@/lib/schema';
-import { TEST_USER_ID, createTestTask } from '@/test/fixtures';
+import { TEST_USER_ID, createTestEvent, createTestTask } from '@/test/fixtures';
 import { and, eq } from 'drizzle-orm';
 
 type NotificationActions = typeof import('@/lib/actions/notifications');
@@ -11,6 +11,7 @@ describe('Notification Scheduling', () => {
   let scheduleNotificationJobs: NotificationActions['scheduleNotificationJobs'];
   let getCurrentUserIdMock: ReturnType<typeof vi.fn>;
   let getUserSettingsMock: ReturnType<typeof vi.fn>;
+  const OTHER_USER_ID = 'other-user-id';
 
   beforeAll(async () => {
     db = await setupTestDb();
@@ -172,6 +173,65 @@ describe('Notification Scheduling', () => {
     getUserSettingsMock.mockResolvedValue({ notificationsEnabled: false });
 
     await scheduleNotificationJobs('task', task.id, dueAt);
+
+    const jobs = await db.select().from(schema.notificationJobs);
+    expect(jobs).toHaveLength(0);
+  });
+
+  it('creates notification jobs for events and ignores disabled configs', async () => {
+    const startAt = new Date('2026-05-10T14:00:00Z');
+    const [event] = await db
+      .insert(schema.events)
+      .values(createTestEvent({ title: 'Event With Notifications', startAt }))
+      .returning();
+
+    await db.insert(schema.notifications).values([
+      {
+        itemType: 'event',
+        itemId: event.id,
+        offsetMinutes: 30,
+        channel: 'email',
+        enabled: true,
+      },
+      {
+        itemType: 'event',
+        itemId: event.id,
+        offsetMinutes: 120,
+        channel: 'email',
+        enabled: false,
+      },
+    ]);
+
+    getUserSettingsMock.mockResolvedValue({ notificationsEnabled: true });
+
+    await scheduleNotificationJobs('event', event.id, startAt);
+
+    const jobs = await db
+      .select()
+      .from(schema.notificationJobs)
+      .where(and(eq(schema.notificationJobs.itemType, 'event'), eq(schema.notificationJobs.itemId, event.id)));
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]?.scheduledAt).toEqual(new Date(startAt.getTime() - 30 * 60000));
+  });
+
+  it('skips scheduling when the parent item is not owned', async () => {
+    const startAt = new Date('2026-06-01T09:00:00Z');
+    const [event] = await db
+      .insert(schema.events)
+      .values(createTestEvent({ userId: OTHER_USER_ID, startAt }))
+      .returning();
+
+    await db.insert(schema.notifications).values({
+      itemType: 'event',
+      itemId: event.id,
+      offsetMinutes: 45,
+      channel: 'email',
+      enabled: true,
+    });
+
+    getUserSettingsMock.mockResolvedValue({ notificationsEnabled: true });
+
+    await scheduleNotificationJobs('event', event.id, startAt);
 
     const jobs = await db.select().from(schema.notificationJobs);
     expect(jobs).toHaveLength(0);

--- a/test/lib/actions/notifications.test.ts
+++ b/test/lib/actions/notifications.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { setupTestDb, teardownTestDb, clearAllTables, getTestDb } from '@/test/db-utils';
+import * as schema from '@/lib/schema';
+import { TEST_USER_ID, createTestEvent, createTestTask } from '@/test/fixtures';
+import { eq } from 'drizzle-orm';
+
+type NotificationActions = typeof import('@/lib/actions/notifications');
+
+const OTHER_USER_ID = 'other-user-id';
+
+describe('Notification Actions', () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  let createNotification: NotificationActions['createNotification'];
+  let updateNotification: NotificationActions['updateNotification'];
+  let deleteNotification: NotificationActions['deleteNotification'];
+  let getNotificationsByItem: NotificationActions['getNotificationsByItem'];
+
+  let getCurrentUserIdMock: ReturnType<typeof vi.fn>;
+
+  beforeAll(async () => {
+    db = await setupTestDb();
+
+    vi.doMock('@/lib/db', () => ({
+      db,
+    }));
+
+    getCurrentUserIdMock = vi.fn().mockResolvedValue(TEST_USER_ID);
+    vi.doMock('@/lib/auth', () => ({
+      getCurrentUserId: getCurrentUserIdMock,
+    }));
+
+    const notificationActions = await import('@/lib/actions/notifications');
+    createNotification = notificationActions.createNotification;
+    updateNotification = notificationActions.updateNotification;
+    deleteNotification = notificationActions.deleteNotification;
+    getNotificationsByItem = notificationActions.getNotificationsByItem;
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    await clearAllTables();
+    vi.clearAllMocks();
+    getCurrentUserIdMock.mockResolvedValue(TEST_USER_ID);
+  });
+
+  it('creates notifications for owned items', async () => {
+    const [event] = await db.insert(schema.events).values(createTestEvent()).returning();
+
+    const result = await createNotification({
+      itemType: 'event',
+      itemId: event.id,
+      offsetMinutes: 30,
+      channel: 'email',
+      enabled: true,
+    });
+
+    expect(result).toEqual({ success: true });
+
+    const notifications = await db.select().from(schema.notifications);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.itemId).toBe(event.id);
+  });
+
+  it('updates notifications when the user owns the parent item', async () => {
+    const [task] = await db.insert(schema.tasks).values(createTestTask()).returning();
+    const [notification] = await db
+      .insert(schema.notifications)
+      .values({
+        itemType: 'task',
+        itemId: task.id,
+        offsetMinutes: 15,
+        channel: 'email',
+        enabled: true,
+      })
+      .returning();
+
+    const result = await updateNotification(notification.id, { offsetMinutes: 45, enabled: false });
+
+    expect(result).toEqual({ success: true });
+
+    const [updated] = await db
+      .select()
+      .from(schema.notifications)
+      .where(eq(schema.notifications.id, notification.id));
+    expect(updated.offsetMinutes).toBe(45);
+    expect(updated.enabled).toBe(false);
+    expect(updated.updatedAt).toBeDefined();
+  });
+
+  it('rejects notification updates when the user does not own the parent item', async () => {
+    const [event] = await db
+      .insert(schema.events)
+      .values(createTestEvent({ userId: OTHER_USER_ID }))
+      .returning();
+    const [notification] = await db
+      .insert(schema.notifications)
+      .values({
+        itemType: 'event',
+        itemId: event.id,
+        offsetMinutes: 10,
+        channel: 'email',
+        enabled: true,
+      })
+      .returning();
+
+    const result = await updateNotification(notification.id, { enabled: false });
+
+    expect(result.success).toBe(false);
+
+    const [unchanged] = await db
+      .select()
+      .from(schema.notifications)
+      .where(eq(schema.notifications.id, notification.id));
+    expect(unchanged.enabled).toBe(true);
+  });
+
+  it('deletes notifications when the user owns the parent item', async () => {
+    const [task] = await db.insert(schema.tasks).values(createTestTask()).returning();
+    const [notification] = await db
+      .insert(schema.notifications)
+      .values({
+        itemType: 'task',
+        itemId: task.id,
+        offsetMinutes: 5,
+        channel: 'email',
+        enabled: true,
+      })
+      .returning();
+
+    const result = await deleteNotification(notification.id);
+    expect(result).toEqual({ success: true });
+
+    const remaining = await db.select().from(schema.notifications);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('rejects notification deletions when the user does not own the parent item', async () => {
+    const [task] = await db
+      .insert(schema.tasks)
+      .values(createTestTask({ userId: OTHER_USER_ID }))
+      .returning();
+    const [notification] = await db
+      .insert(schema.notifications)
+      .values({
+        itemType: 'task',
+        itemId: task.id,
+        offsetMinutes: 20,
+        channel: 'email',
+        enabled: true,
+      })
+      .returning();
+
+    const result = await deleteNotification(notification.id);
+    expect(result.success).toBe(false);
+
+    const remaining = await db.select().from(schema.notifications);
+    expect(remaining).toHaveLength(1);
+  });
+
+  it('returns notifications for owned items and nothing for non-owned items', async () => {
+    const [task] = await db.insert(schema.tasks).values(createTestTask()).returning();
+    await db.insert(schema.notifications).values([
+      {
+        itemType: 'task',
+        itemId: task.id,
+        offsetMinutes: 15,
+        channel: 'email',
+        enabled: true,
+      },
+      {
+        itemType: 'task',
+        itemId: task.id,
+        offsetMinutes: 60,
+        channel: 'email',
+        enabled: true,
+      },
+    ]);
+
+    const ownedNotifications = await getNotificationsByItem('task', task.id);
+    expect(ownedNotifications).toHaveLength(2);
+
+    const [otherTask] = await db
+      .insert(schema.tasks)
+      .values(createTestTask({ userId: OTHER_USER_ID }))
+      .returning();
+    await db.insert(schema.notifications).values({
+      itemType: 'task',
+      itemId: otherTask.id,
+      offsetMinutes: 30,
+      channel: 'email',
+      enabled: true,
+    });
+
+    const otherNotifications = await getNotificationsByItem('task', otherTask.id);
+    expect(otherNotifications).toHaveLength(0);
+  });
+
+  it('returns empty when the parent item does not exist', async () => {
+    await db.insert(schema.notifications).values({
+      itemType: 'event',
+      itemId: 9999,
+      offsetMinutes: 30,
+      channel: 'email',
+      enabled: true,
+    });
+
+    const notifications = await getNotificationsByItem('event', 9999);
+    expect(notifications).toHaveLength(0);
+  });
+});

--- a/test/use-long-press.test.ts
+++ b/test/use-long-press.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { renderHook, act } from '@testing-library/react';
 import { useLongPress } from '@/lib/hooks/use-long-press';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';

--- a/test/use-selection.test.ts
+++ b/test/use-selection.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { renderHook, act } from '@testing-library/react';
 import { useSelection } from '@/lib/hooks/use-selection';
 import { describe, it, expect, vi } from 'vitest';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     globals: true,
-    environment: 'happy-dom',
+    environment: 'node',
     setupFiles: ['./test/setup.ts'],
     include: ['**/*.{test,spec}.{ts,tsx}'],
     exclude: ['node_modules', '.next', 'out', 'drizzle', 'test/e2e'],


### PR DESCRIPTION
## Summary
- add importMixed tests for installments, partial imports, and mixed expense/income
- add notification action CRUD/ownership tests
- extend notification scheduling tests for events and ownership checks

## Testing
- pnpm test:run -- test/lib/actions/import.test.ts test/lib/actions/notifications.test.ts test/lib/actions/notifications-scheduling.test.ts (fails: EPERM connect ::1:3000 in sandbox)
- pnpm lint
- pnpm build

Closes northstar-g28
Closes northstar-8az

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded import tests covering duplicates, installment scenarios, mixed income/expense batches, and re-import skipping.
  * Added notification scheduling tests for enabled/disabled configs and ownership checks.
  * Added comprehensive notification action tests for create/update/delete/retrieve behaviors.
* **Chores**
  * Standardized test environment directives and updated test runner config.
  * Added test fetch interception to block real network calls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->