### PR TITLE
fix(import): restrict file types based on selected parser template

### DIFF
--- a/components/import/import-modal.tsx
+++ b/components/import/import-modal.tsx
@@ -39,6 +39,12 @@ export function ImportModal({ accounts, categories }: Props) {
   const tErrors = useTranslations('errors');
   const tParsers = useTranslations('parsers');
 
+  // Determine accepted file extension based on parser type
+  const getAcceptedFileType = (template: ParserKey | null): string => {
+    if (!template) return '.csv,.ofx';
+    return template.endsWith('-ofx') ? '.ofx' : '.csv';
+  };
+
   const handleFileSelect = async (content: string) => {
     if (!selectedTemplate) return;
 
@@ -249,7 +255,7 @@ export function ImportModal({ accounts, categories }: Props) {
                       : parsers[selectedTemplate].name,
                   })}
                 </h3>
-                <FileDropzone onFileContent={handleFileSelect} />
+                <FileDropzone onFileContent={handleFileSelect} accept={getAcceptedFileType(selectedTemplate)} />
               </div>
 
               <Button variant="outline" onClick={() => setStep('template')} className="w-full">


### PR DESCRIPTION
CSV parsers now only accept .csv files and OFX parsers only accept .ofx
files, fixing the issue where both file types were incorrectly accepted
for all import templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * File upload now validates file types based on the selected parser template, accepting both CSV and OFX by default, or restricting to the appropriate format when a specific template is chosen.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->