### PR TITLE
feat(installments): place subsequent installments at fatura window start

### DIFF
--- a/lib/fatura-utils.ts
+++ b/lib/fatura-utils.ts
@@ -169,3 +169,37 @@ export function getFaturaMonthFromClosingDate(
     return `${year}-${String(month).padStart(2, '0')}`;
   }
 }
+
+/**
+ * Computes the start date of a fatura billing window.
+ *
+ * The fatura window starts the day after the previous month's closing date.
+ * This is used to determine the purchaseDate for installments after the first one.
+ *
+ * Example: For Feb 2025 fatura with closingDay=15
+ * - Previous fatura (Jan) closes on 2025-01-15
+ * - Feb fatura window starts on 2025-01-16
+ *
+ * @param yearMonth - Fatura month in "YYYY-MM" format
+ * @param closingDay - Day of month when statement closes (1-28)
+ * @returns Start date of the billing window in "YYYY-MM-DD" format
+ */
+export function computeFaturaWindowStart(yearMonth: string, closingDay: number): string {
+  const [year, month] = yearMonth.split('-').map(Number);
+
+  // Get the previous month
+  const prevMonthDate = new Date(Date.UTC(year, month - 2, 1)); // month is 1-indexed, Date uses 0-indexed
+  const prevYear = prevMonthDate.getUTCFullYear();
+  const prevMonth = prevMonthDate.getUTCMonth(); // 0-indexed
+
+  // Get the last day of the previous month
+  const lastDayOfPrevMonth = new Date(Date.UTC(prevYear, prevMonth + 1, 0)).getUTCDate();
+
+  // The previous month's closing day (adjusted if month has fewer days)
+  const actualClosingDay = Math.min(closingDay, lastDayOfPrevMonth);
+
+  // Window starts the day after the previous closing date
+  const startDate = new Date(Date.UTC(prevYear, prevMonth, actualClosingDay + 1));
+
+  return startDate.toISOString().split('T')[0];
+}

--- a/test/lib/actions/expenses.test.ts
+++ b/test/lib/actions/expenses.test.ts
@@ -507,6 +507,10 @@ describe('Expense Actions - Happy Path', () => {
   describe('installments span multiple faturas', () => {
     it('creates entries with correct faturaMonth and dueDate for each installment', async () => {
       // Purchase on Jan 10, 3 installments
+      // With new behavior:
+      // - Installment 1: purchaseDate = actual (Jan 10), faturaMonth = Jan
+      // - Installment 2: purchaseDate = fatura window start (Jan 16), faturaMonth = Feb
+      // - Installment 3: purchaseDate = fatura window start (Feb 16), faturaMonth = Mar
       await createExpense({
         description: 'Multi-installment',
         totalAmount: 30000,
@@ -520,19 +524,19 @@ describe('Expense Actions - Happy Path', () => {
       expect(expenses).toHaveLength(3);
 
       // Ordered desc by dueDate, so newest first
-      // Entry 3 (Mar): purchaseDate=2025-03-10, faturaMonth=2025-03, dueDate=2025-04-05
+      // Entry 3 (Mar): purchaseDate=2025-02-16 (fatura window start), faturaMonth=2025-03, dueDate=2025-04-05
       expect(expenses[0].installmentNumber).toBe(3);
-      expect(expenses[0].purchaseDate).toBe('2025-03-10');
+      expect(expenses[0].purchaseDate).toBe('2025-02-16');
       expect(expenses[0].faturaMonth).toBe('2025-03');
       expect(expenses[0].dueDate).toBe('2025-04-05');
 
-      // Entry 2 (Feb): purchaseDate=2025-02-10, faturaMonth=2025-02, dueDate=2025-03-05
+      // Entry 2 (Feb): purchaseDate=2025-01-16 (fatura window start), faturaMonth=2025-02, dueDate=2025-03-05
       expect(expenses[1].installmentNumber).toBe(2);
-      expect(expenses[1].purchaseDate).toBe('2025-02-10');
+      expect(expenses[1].purchaseDate).toBe('2025-01-16');
       expect(expenses[1].faturaMonth).toBe('2025-02');
       expect(expenses[1].dueDate).toBe('2025-03-05');
 
-      // Entry 1 (Jan): purchaseDate=2025-01-10, faturaMonth=2025-01, dueDate=2025-02-05
+      // Entry 1 (Jan): purchaseDate=2025-01-10 (actual purchase), faturaMonth=2025-01, dueDate=2025-02-05
       expect(expenses[2].installmentNumber).toBe(1);
       expect(expenses[2].purchaseDate).toBe('2025-01-10');
       expect(expenses[2].faturaMonth).toBe('2025-01');

--- a/test/lib/actions/import.test.ts
+++ b/test/lib/actions/import.test.ts
@@ -344,14 +344,19 @@ describe('Import Actions', () => {
         .where(eq(schema.entries.transactionId, transaction.id));
       expect(entries).toHaveLength(2);
 
+      // With new behavior: subsequent installments use fatura window start
+      // Base purchase date is calculated: parcela 2 date (Jan 20) - 1 month = Dec 20
+      // Base fatura month: Dec 20 is after closing day 15, so base fatura = Jan
+      // Entry 2: faturaMonth = Feb, purchaseDate = fatura window start = Jan 16
+      // Entry 3: faturaMonth = Mar, purchaseDate = fatura window start = Feb 16
       const entry2 = entries.find((entry) => entry.installmentNumber === 2);
       const entry3 = entries.find((entry) => entry.installmentNumber === 3);
 
-      expect(entry2?.purchaseDate).toBe('2025-01-20');
+      expect(entry2?.purchaseDate).toBe('2025-01-16');
       expect(entry2?.faturaMonth).toBe('2025-02');
       expect(entry2?.dueDate).toBe('2025-03-05');
 
-      expect(entry3?.purchaseDate).toBe('2025-02-20');
+      expect(entry3?.purchaseDate).toBe('2025-02-16');
       expect(entry3?.faturaMonth).toBe('2025-03');
       expect(entry3?.dueDate).toBe('2025-04-05');
       expect(entry3?.amount).toBe(120000);


### PR DESCRIPTION
Multi-installment purchases now place entries for installments 2+ at the
first day of their respective fatura billing window instead of using a
calculated date based on the original purchase day.

Changes:
- Add computeFaturaWindowStart() utility in fatura-utils.ts
- Add getFaturaWindowStart() server action that checks for custom startDate
  overrides in the database
- Update createExpense() and updateExpense() to use fatura window start
  for subsequent installments
- Update computeEntryDates() in import.ts with same logic
- Add recalculateInstallmentDates() to update entries when fatura dates change
- Integrate recalculation into updateFaturaDates() with cascading support
- Update tests to expect new behavior

Example:
Purchase on Jan 10, 3 installments (closingDay=15):
- Installment 1: purchaseDate=2025-01-10, faturaMonth=2025-01
- Installment 2: purchaseDate=2025-01-16, faturaMonth=2025-02
- Installment 3: purchaseDate=2025-02-16, faturaMonth=2025-03

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Multi-installment credit card expenses now correctly set purchase dates: first installment retains actual purchase date; subsequent installments use fatura window start dates
  * Improved due date accuracy across billing period boundaries
  * Enhanced billing window calculations for more precise date handling

* **Tests**
  * Updated test expectations for multi-installment scenarios reflecting new date calculation behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->